### PR TITLE
Feat/facilitate draft blogs creation

### DIFF
--- a/Talkish.API/Controllers/AuthController.cs
+++ b/Talkish.API/Controllers/AuthController.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,7 +23,7 @@ namespace Talkish.API.Controllers
         }
 
         [HttpPost]
-        [Route("registration")]
+        [Route("register")]
         public async Task<IActionResult> Register([FromBody] RegisterDTO RegistrationData)
         {
             if (ModelState.IsValid)

--- a/Talkish.API/Controllers/BlogsController.cs
+++ b/Talkish.API/Controllers/BlogsController.cs
@@ -101,10 +101,11 @@ namespace Talkish.API.Controllers
                 Blog blog = _mapper.Map<Blog>(BlogData);
                 Blog createdBlog = await _service.CreateBlog(blog);
 
+                CreatedBlogDTO createdBlogId = _mapper.Map<CreatedBlogDTO>(createdBlog);
 
                 SuccessResponse response = new()
                 {
-                    Payload = BlogData,
+                    Payload = createdBlogId,
                     Status = 201
                 };
 

--- a/Talkish.API/DTOs/BlogDTOs/AddBlogDTO.cs
+++ b/Talkish.API/DTOs/BlogDTOs/AddBlogDTO.cs
@@ -1,16 +1,16 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Talkish.API.DTOs
 {
     public class AddBlogDTO
     {
-        [Required]
         [Display(Name = "Blog Title")]
         [DataType(DataType.Text)]
         public string Title { get; set; }
 
-        [Required]
         [DataType(DataType.Text)]
         [Display(Name = "Blog Content")]
         public string Content { get; set; }

--- a/Talkish.API/DTOs/BlogDTOs/AddBlogDTO.cs
+++ b/Talkish.API/DTOs/BlogDTOs/AddBlogDTO.cs
@@ -8,13 +8,11 @@ namespace Talkish.API.DTOs
         [Required]
         [Display(Name = "Blog Title")]
         [DataType(DataType.Text)]
-        [StringLength(100, MinimumLength = 3, ErrorMessage = "Blog Title must be longer than 3 characters, but shorter than 100")]
         public string Title { get; set; }
 
         [Required]
         [DataType(DataType.Text)]
         [Display(Name = "Blog Content")]
-        [StringLength(100000, MinimumLength = 30, ErrorMessage = "Blog content must be longer than 30 characters")]
         public string Content { get; set; }
 
         public bool IsDraft { get; set; }

--- a/Talkish.API/DTOs/BlogDTOs/AddBlogDTO.cs
+++ b/Talkish.API/DTOs/BlogDTOs/AddBlogDTO.cs
@@ -17,6 +17,8 @@ namespace Talkish.API.DTOs
         [StringLength(100000, MinimumLength = 30, ErrorMessage = "Blog content must be longer than 30 characters")]
         public string Content { get; set; }
 
+        public bool IsDraft { get; set; }
+
         [ForeignKey("Author")]
         public int AuthorId { get; set; }
     }

--- a/Talkish.API/DTOs/BlogDTOs/CreatedBlogDTO.cs
+++ b/Talkish.API/DTOs/BlogDTOs/CreatedBlogDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace Talkish.API.DTOs
+{
+    public class CreatedBlogDTO
+    {
+        public int BlogId { get; set; }
+    }
+}

--- a/Talkish.API/Profiles/BlogProfiles.cs
+++ b/Talkish.API/Profiles/BlogProfiles.cs
@@ -18,6 +18,8 @@ namespace Talkish.API.Profiles
                 .ReverseMap();
 
             CreateMap<Blog, BlogDTO>();
+
+            CreateMap<Blog, CreatedBlogDTO>();
         }
     }
 }

--- a/Talkish.Domain/Models/Blog.cs
+++ b/Talkish.Domain/Models/Blog.cs
@@ -22,7 +22,7 @@ namespace Talkish.Domain.Models
         public string Content { get; set; }
 
         [Display(Name = "Draft Story")]
-        public bool IsDraft { get; set; } = false;
+        public bool IsDraft { get; set; } = true;
 
         [DataType(DataType.DateTime)]
         [Display(Name = "Published At")]

--- a/Talkish.Domain/Models/Blog.cs
+++ b/Talkish.Domain/Models/Blog.cs
@@ -9,12 +9,10 @@ namespace Talkish.Domain.Models
         [Key]
         public int BlogId { get; set; }
 
-        [Required]
         [Display(Name = "Blog Title")]
         [DataType(DataType.Text)]
         public string Title { get; set; }
 
-        [Required]
         [DataType(DataType.Text)]
         [Display(Name = "Blog Content")]
         public string Content { get; set; }

--- a/Talkish.Domain/Models/Blog.cs
+++ b/Talkish.Domain/Models/Blog.cs
@@ -12,13 +12,11 @@ namespace Talkish.Domain.Models
         [Required]
         [Display(Name = "Blog Title")]
         [DataType(DataType.Text)]
-        [StringLength(100, MinimumLength = 3, ErrorMessage = "Blog Title must be longer than 3 characters, but shorter than 100")]
         public string Title { get; set; }
 
         [Required]
         [DataType(DataType.Text)]
         [Display(Name = "Blog Content")]
-        [StringLength(100000, MinimumLength = 30, ErrorMessage = "Blog content must be longer than 30 characters")]
         public string Content { get; set; }
 
         [Display(Name = "Draft Story")]

--- a/Talkish.Services/AuthService.cs
+++ b/Talkish.Services/AuthService.cs
@@ -197,15 +197,15 @@ namespace Talkish.Services
         {
             var claimsIdentity = new ClaimsIdentity(new Claim[]
             {
-            new Claim(JwtRegisteredClaimNames.Sub, identityUser.Email),
-            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-            new Claim(JwtRegisteredClaimNames.Email, identityUser.Email),
-            new Claim("IdentityId", identityUser.Id),
-            new Claim("UserId", user.UserId.ToString())
+                new Claim(JwtRegisteredClaimNames.Sub, identityUser.Email),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+                new Claim(JwtRegisteredClaimNames.Email, identityUser.Email),
+                new Claim("IdentityId", identityUser.Id),
+                new Claim("UserId", user.UserId.ToString())
             });
 
-            var token = this.CreateSecurityToken(claimsIdentity);
-            return this.WriteToken(token);
+            var token = CreateSecurityToken(claimsIdentity);
+            return WriteToken(token);
         }
     }
 }


### PR DESCRIPTION
- Add CreatedBlogDTO to be used in order to capture the id of a newly created blog
- Removed Blog & AddBlogDTO' validation for the `Title` & `Content` fields in order to facilitate the creation of draft blogs, which might have a single character in the beginning
- Add validation in the blogs controller to make sure that the client will supply either a `Title` field value, or a `Content` field value
- Blogs will always be created as `drafts`, unless specified otherwise from the client